### PR TITLE
fix: Podmanを利用して`./manage-offline-container-images.sh register`を実行すると、image_idの取得に失敗し、スクリプトが中断される

### DIFF
--- a/contrib/offline/manage-offline-container-images.sh
+++ b/contrib/offline/manage-offline-container-images.sh
@@ -125,7 +125,7 @@ function register_container_images() {
 
 	tar -zxvf ${IMAGE_TAR_FILE}
 
-	if [ "${create_registry}" ]; then
+	if ${create_registry}; then
 		sudo ${runtime} load -i ${IMAGE_DIR}/registry-latest.tar
 		set +e
 

--- a/contrib/offline/manage-offline-container-images.sh
+++ b/contrib/offline/manage-offline-container-images.sh
@@ -146,7 +146,11 @@ function register_container_images() {
 		if [ "${org_image}" == "ID:" ]; then
 		  org_image=$(echo "${load_image}"  | awk '{print $4}')
 		fi
-		image_id=$(sudo ${runtime} image inspect ${org_image} | grep "\"Id\":" | awk -F: '{print $3}'| sed s/'\",'//)
+		if [ "${runtime}" == "podman" ]; then
+		  image_id=$(sudo -E "${runtime}" image inspect "${org_image}" | grep "\"Id\":" | awk -F: '{print $2}'| sed 's/[",]//g')
+		else
+		  image_id=$(sudo -E "${runtime}" image inspect "${org_image}" | grep "\"Id\":" | awk -F: '{print $3}'| sed s/'\",'//)
+		fi
 		if [ -z "${file_name}" ]; then
 			echo "Failed to get file_name for line ${line}"
 			exit 1

--- a/contrib/offline/manage-offline-container-images.sh
+++ b/contrib/offline/manage-offline-container-images.sh
@@ -125,7 +125,7 @@ function register_container_images() {
 
 	tar -zxvf ${IMAGE_TAR_FILE}
 
-	if ${create_registry}; then
+	if [ "${create_registry}" ]; then
 		sudo ${runtime} load -i ${IMAGE_DIR}/registry-latest.tar
 		set +e
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Podmanで./manage-offline-container-images.sh registerでコンテナレジストリにイメージを登録しようとすると、以下のエラーが出力される。
```
Getting image source signatures
Copying blob b972131a1dcc skipped: already exists
Copying blob 011b303988d2 skipped: already exists
Copying blob a4be933f3ee0 skipped: already exists
Copying config 3fe402881a done   |
Writing manifest to image destination
Failed to get image_id for file docker.io-mirantis-k8s-netchecker-server-v1.2.2.tar
```
エラーの内容を見ると、image_idの取得に失敗しているようだった。

* スクリプト内の該当箇所確認
```
image_id=$(${runtime} image inspect ${org_image} | grep "\"Id\":" | awk -F: '{print $3}'| sed s/'\",'//)
```

runtimeとして、docker,Podman,nerdctlを利用できる。
dockerとnerdctlのimage_idの出力方法は同じだが、Podmanのみ異なっているため、idの取得方法をpodmanとその他で分けるように修正が必要である。

* Podman
```
# podman image inspect <image>
          "Id": "XXX",
```

* Docker
```
# docker image inspect <image>
        "Id": "sha256:XXX",
```

* nerdctl
```
# nerdctl image inspect <image>
        "Id": "sha256:XXX",
```


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix: Podmanを利用して`./manage-offline-container-images.sh register`を実行すると、image_idの取得に失敗し、スクリプトが中断される
```
