### PR TITLE
fix manage-offline-container-images.sh create_registry

### DIFF
--- a/contrib/offline/manage-offline-container-images.sh
+++ b/contrib/offline/manage-offline-container-images.sh
@@ -125,7 +125,7 @@ function register_container_images() {
 
 	tar -zxvf ${IMAGE_TAR_FILE}
 
-	if [ "${create_registry}" ]; then
+	if ${create_registry}; then
 		sudo ${runtime} load -i ${IMAGE_DIR}/registry-latest.tar
 		set +e
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

コンテナレジストリを自身ですでに作成済のため、そこにイメージを登録したいのだが、以下のコマンドでコンテナレジストリにイメージを登録しようとすると、regsitryという新しいコンテナが作成され、そこにイメージが登録されてしまう。
```
# export DESTINATION_REGISTRY=192.168.122.155:5000 #既存コンテナレジストリを指定
# ./manage-offline-container-images.sh register
```

* コンテナの確認
```
# podman ps -a
CONTAINER ID  IMAGE                              COMMAND               CREATED             STATUS       PORTS                   NAMES
d90b84b7c726  docker.io/library/registry:2.8.2   /etc/docker/regis...  15 hours ago        Up 15 hours  0.0.0.0:5000->5000/tcp  docker-distribution
b2ab51819745  docker.io/library/nginx:alpine     nginx -g daemon o...  15 hours ago        Up 15 hours  0.0.0.0:8080->80/tcp    nginx
61997afcca9e  docker.io/library/registry:latest  /etc/docker/regis...  About a minute ago  Created      0.0.0.0:5000->5000/tcp  registry
```

スクリプト内を確認してみると、以下の手順でコンテナレジストリを作成しているようだった。

```
if [ "${create_registry}" ]; then
		sudo ${runtime} load -i ${IMAGE_DIR}/registry-latest.tar
		set +e

		sudo ${runtime} container inspect registry >/dev/null 2>&1
		if [ $? -ne 0 ]; then
			sudo ${runtime} run --restart=always -d -p "${REGISTRY_PORT}":"${REGISTRY_PORT}" --name registry registry:latest
		fi
		set -e
	fi
```

上記の`create_registry`は以下から算出されている。

```
function register_container_images() {
	create_registry=false
	REGISTRY_PORT=${REGISTRY_PORT:-"5000"}

	if [ -z "${DESTINATION_REGISTRY}" ]; then
		echo "DESTINATION_REGISTRY not set, will create local registry"
		create_registry=true
		DESTINATION_REGISTRY="$(hostname):${REGISTRY_PORT}"
	fi
	echo "Images will be pushed to ${DESTINATION_REGISTRY}"
```

本来はすでにレジストリが存在し、そこにイメージをpushしたい場合、`REGISTRY_PORT`にレジストリのアドレスを設定する。
`REGISTRY_PORT`が設定されていない場合は、ローカルレジストリにコンテナレジストリを作成し、そこにpushされるような意味だと認識している。

上記の設定に基づく場合、本来は`create_registry`が`false`の場合は手順を実行せず、`true`の場合に手順を実行するのが正しい。
しかし、`if [ "${create_registry}" ]; then`の通り、`create_registry`変数が設定されていると作成するような手順になってしまっているため、push先のコンテナレジストリを指定していてもいなくても、ローカルレジストリを作成するようになってしまっていた。

そのため、以下のように変更することで事象を修正する必要がある。

```
if ${create_registry}; then
                 ${runtime} load -i ${IMAGE_DIR}/registry-latest.tar
                set +e

                 ${runtime} container inspect registry >/dev/null 2>&1
                if [ $? -ne 0 ]; then
                         ${runtime} run --restart=always -d -p "${REGISTRY_PORT}":"${REGISTRY_PORT}" --name registry registry:latest
                fi
                set -e
        fi
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix: オフライン検証で既存のコンテナレジストリにイメージが登録されず、新しいコンテナが作成される。
```
